### PR TITLE
Admin contact

### DIFF
--- a/coreapis/clientadm/controller.py
+++ b/coreapis/clientadm/controller.py
@@ -328,6 +328,7 @@ class ClientAdmController(CrudControllerBase):
             orgauthz = {key: json.loads(val) for key, val in orgauthz.items()}
         gkclient.update({'orgauthorization': orgauthz})
         gkclient.update({attr: [] for attr in self.scope_attrs})
+        gkclient.update({'admin_contact': self.get_admin_contact(client)})
         for attr in self.scope_attrs:
             clientscopes = client[attr]
             if clientscopes:

--- a/coreapis/clientadm/tests/test_cadmcontroller.py
+++ b/coreapis/clientadm/tests/test_cadmcontroller.py
@@ -136,3 +136,8 @@ class TestController(TestCase):
         self.session.get_user_by_id.return_value = retrieved_user
         res = self.controller.get_gkscope_clients([testgk, othergk])
         assert len(res) == 3
+
+    def test_get_admin_contact_bad_owner(self):
+        self.session.get_user_by_id.side_effect = KeyError
+        res = self.controller.get_admin_contact(retrieved_gk_client)
+        assert not res

--- a/coreapis/crud_base.py
+++ b/coreapis/crud_base.py
@@ -7,7 +7,7 @@ from PIL import Image
 
 from coreapis.utils import (
     now, ValidationError, AlreadyExistsError, LogWrapper, get_feideids, public_userinfo,
-    public_orginfo, PRIV_PLATFORM_ADMIN)
+    public_orginfo, preferred_email, PRIV_PLATFORM_ADMIN)
 
 LOGO_SIZE = 128, 128
 
@@ -187,3 +187,16 @@ class CrudControllerBase(object):
                 'name': 'Unknown user',
             }
         return pubtarget
+
+    def get_admin_contact(self, target):
+        contact = target.get('admin_contact', '')
+        if contact:
+            return contact
+        try:
+            owner_uuid = target.get('owner')
+            contact = preferred_email(self.session.get_user_by_id(owner_uuid))
+        except KeyError:
+            logdata = dict(userid=target['owner'])
+            logdata[self.objtype + 'id'] = target['id']
+            self.log.warn('{} owner does not exist in users table'.format(self.objtype), **logdata)
+        return contact

--- a/coreapis/scopes/manager.py
+++ b/coreapis/scopes/manager.py
@@ -1,5 +1,5 @@
 from coreapis.utils import (
-    EmailNotifier, json_load, LogWrapper, ValidationError, PRIV_PLATFORM_ADMIN)
+    EmailNotifier, json_load, preferred_email, LogWrapper, ValidationError, PRIV_PLATFORM_ADMIN)
 from .scope_request_notification import ScopeRequestNotification
 from coreapis.scopes import filter_missing_mainscope, gk_mainscope, is_gkscopename
 
@@ -56,10 +56,7 @@ class ScopesManager(object):
         if admin_contact:
             return admin_contact
         owner = self.session.get_user_by_id(apigk['owner'])
-        try:
-            return list(owner['email'].values())[0]
-        except (AttributeError, IndexError):
-            return None
+        return preferred_email(owner)
 
     def _get_moderator(self, scope):
         if is_gkscopename(scope):

--- a/coreapis/tests/test_utils.py
+++ b/coreapis/tests/test_utils.py
@@ -25,6 +25,32 @@ class TestMisc(TestCase):
         assert utils.public_userinfo(input) == output
 
 
+class TestPreferredEmail(TestCase):
+    def test_ok(self):
+        user = {
+            'email': {'feide:example.org': 'test@example.org'},
+            'userid': uuid.uuid4(),
+            'selectedsource': 'feide:example.org',
+        }
+        assert utils.preferred_email(user) == 'test@example.org'
+
+    def test_empty(self):
+        assert utils.preferred_email({}) is None
+
+    def test_no_selectedsource(self):
+        user = {
+            'email': {'feide:example.org': 'test@example.org'},
+            'userid': uuid.uuid4(),
+        }
+        assert utils.preferred_email(user) == 'test@example.org'
+
+    def test_no_addr(self):
+        user = {
+            'email': {'feide:example.org': ''},
+            'userid': uuid.uuid4(),
+        }
+        assert utils.preferred_email(user) is None
+
 class TestGetFeideids(TestCase):
     def test_ok(self):
         user = {

--- a/coreapis/utils.py
+++ b/coreapis/utils.py
@@ -354,6 +354,22 @@ def public_userinfo(user):
     }
 
 
+def preferred_email(user):
+    pairs = user.get('email', {})
+    if not pairs:
+        return None
+    try:
+        addr = pairs[user['selectedsource']]
+    except KeyError:
+        addr = None
+    if not addr:
+        try:
+            addrs = [val for val in pairs.values() if val]
+            addr = addrs[0]
+        except IndexError:
+            addr = None
+    return addr
+
 def public_orginfo(org):
     return {
         'id': org['id'],


### PR DESCRIPTION
To enable showing admin contacts of api consumers in dashboard.
admin_contact added to view of clients returned by apigk_{owner|delegate|org}_clients.

Uses admin_contact if set, otherwise falls back to client owner's preferred email.

You have to be an api admin to use these calls, so exposing emails should be OK.

They give contacts for many apis, but you can select based on scopes in the result.

Example 

```
curl -k -H "Authorization: Bearer $TOKEN" \
   'https://apigkadmin.gk.127.0.0.1.xip.io/apigks/owners/654f24a9-90e9-4dc1-9112-7f32fb77753d/clients/' | \
   jq '.[] | {name: .name, admin_contact: .admin_contact, scopes: .scopes, scopes_requested: .scopes_requested}'
[
  {
    "name": "foo",
    "admin_contact": "jon.kare.hellan@uninett.no",
    "scopes": [
      "gk_hei"
    ],
    "scopes_requested": [
      "gk_hei"
    ]
  },
  {
    "name": "erger",
    "admin_contact": "jon.kare.hellan@uninett.no",
    "scopes": [
      "gk_hei"
    ],
    "scopes_requested": [
      "gk_hei"
    ]
  }
]

```